### PR TITLE
Information display updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,12 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea
+
+# Vim
+.viminfo
+# Less history
+.lesshst
+

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ target/
 # Less history
 .lesshst
 
+.dbshell
+.emacs*
+.ipython
+.mongo*
+*.properties
+

--- a/bin/biomaj-cli.py
+++ b/bin/biomaj-cli.py
@@ -278,9 +278,6 @@ def main():
             if options.query:
                 res = Bank.searchindex(options.query)
                 print("Query matches for :"+options.query)
-                res = [{'_source':{'release': '1', 'format': 'format1','types':'nucl,prot','files':['file1','file2','file3']}},
-                       {'_source':{'release': '2', 'format': 'format2','types':'nucl','files':['file4','file5','file6']}},
-                       {'_source':{'release': '3', 'format': 'format3','types':'nucl,prot','files':['file1','file2','file3']}}]
                 results = [["Release", "Format(s)", "Type(s)", "Files"]]
                 for match in res:
                     results.append([match['_source']['release'],

--- a/bin/biomaj-cli.py
+++ b/bin/biomaj-cli.py
@@ -30,35 +30,35 @@ def main():
     parser.add_argument('-p', '--publish', dest="publish", help="Publish", action="store_true", default=False)
     parser.add_argument('--unpublish', dest="unpublish", help="Unpublish", action="store_true", default=False)
 
-    parser.add_argument('--release', dest="release",help="release of the bank")
-    parser.add_argument('--from-task', dest="from_task",help="Start cycle at a specific task (init always executed)")
-    parser.add_argument('--process', dest="process",help="Linked to from-task, optionally specify a block, meta or process name to start from")
-    parser.add_argument('-l', '--log', dest="log",help="log level")
+    parser.add_argument('--release', dest="release", help="release of the bank")
+    parser.add_argument('--from-task', dest="from_task", help="Start cycle at a specific task (init always executed)")
+    parser.add_argument('--process', dest="process", help="Linked to from-task, optionally specify a block, meta or process name to start from")
+    parser.add_argument('-l', '--log', dest="log", help="log level")
     parser.add_argument('-r', '--remove', dest="remove", help="Remove a bank release", action="store_true", default=False)
     parser.add_argument('--remove-all', dest="removeall", help="Remove all bank releases and database records", action="store_true", default=False)
     parser.add_argument('--remove-pending', dest="removepending", help="Remove pending release", action="store_true", default=False)
     parser.add_argument('-s', '--status', dest="status", help="Get status", action="store_true", default=False)
-    parser.add_argument('-b', '--bank', dest="bank",help="bank name")
+    parser.add_argument('-b', '--bank', dest="bank", help="bank name")
     parser.add_argument('--owner', dest="owner", help="change owner of the bank")
-    parser.add_argument('--stop-before', dest="stop_before",help="Store workflow before task")
-    parser.add_argument('--stop-after', dest="stop_after",help="Store workflow after task")
+    parser.add_argument('--stop-before', dest="stop_before", help="Store workflow before task")
+    parser.add_argument('--stop-after', dest="stop_after", help="Store workflow after task")
     parser.add_argument('--freeze', dest="freeze", help="Freeze a bank release", action="store_true", default=False)
     parser.add_argument('--unfreeze', dest="unfreeze", help="Unfreeze a bank release", action="store_true", default=False)
     parser.add_argument('-f', '--force', dest="force", help="Force action", action="store_true", default=False)
     parser.add_argument('-h', '--help', dest="help", help="Show usage", action="store_true", default=False)
 
     parser.add_argument('--search', dest="search", help="Search by format and types", action="store_true", default=False)
-    parser.add_argument('--formats', dest="formats",help="List of formats to search, comma separated")
-    parser.add_argument('--types', dest="types",help="List of types to search, comma separated")
-    parser.add_argument('--query', dest="query",help="Lucene query syntax to search in index")
+    parser.add_argument('--formats', dest="formats", help="List of formats to search, comma separated")
+    parser.add_argument('--types', dest="types", help="List of types to search, comma separated")
+    parser.add_argument('--query', dest="query", help="Lucene query syntax to search in index")
 
     parser.add_argument('--show', dest="show", help="Show format files for selected bank", action="store_true", default=False)
 
-    parser.add_argument('-n', '--change-dbname', dest="newbank",help="Change old bank name to this new bank name")
+    parser.add_argument('-n', '--change-dbname', dest="newbank", help="Change old bank name to this new bank name")
     parser.add_argument('-e', '--move-production-directories', dest="newdir",help="Change bank production directories location to this new path, path must exists")
-    parser.add_argument('--visibility', dest="visibility",help="visibility status of the bank")
+    parser.add_argument('--visibility', dest="visibility", help="visibility status of the bank")
 
-    parser.add_argument('--maintenance', dest="maintenance",help="Maintenance mode (on/off/status)")
+    parser.add_argument('--maintenance', dest="maintenance", help="Maintenance mode (on/off/status)")
 
     parser.add_argument('--version', dest="version", help="Show version", action="store_true", default=False)
 
@@ -208,7 +208,6 @@ def main():
                 print("Maintenance set to Off")
                 sys.exit(0)
 
-
         if options.owner:
             if not options.bank:
                 print("Bank option is missing")
@@ -235,7 +234,7 @@ def main():
                 sys.exit(1)
             if not os.path.exists(options.newdir):
                 print("Destination directory does not exists")
-            bank = Bank(options.bank, options= options, no_log=True)
+            bank = Bank(options.bank, options=options, no_log=True)
             if not bank.bank['production']:
                 print("Nothing to move, no production directory")
                 sys.exit(0)
@@ -295,17 +294,17 @@ def main():
                     types = options.types.split(',')
                 print("Search by formats="+str(formats)+", types="+str(types))
                 res = Bank.search(formats, types, False)
-                print('#' * 80)
-                print("# Name\tRelease")
-                for bank in res:
-                    print(" "+bank['name'])
+                results = [["Name", "Release", "Format(s)", "Type(s)", 'Current']]
+                for bank in sorted(res, key=lambda bank: (bank['name'], bank['production'])):
+                    b = bank['name']
                     for prod in bank['production']:
                         iscurrent = ""
                         if prod['session'] == bank['current']:
-                            iscurrent = "current"
-                        print(" \t"+prod['release']+"\t"+','.join(prod['formats'])+"\t"+','.join(prod['types'])+"\t"+iscurrent)
-
-                print('#' * 80)
+                            iscurrent = "yes"
+                        results.append([b if b else '', prod['release'], ','.join(prod['formats']),
+                                        ','.join(prod['types']), iscurrent])
+                        b = None
+                print(tabulate(results, headers="firstrow", tablefmt="grid"))
                 sys.exit(0)
 
         if options.show:
@@ -344,7 +343,6 @@ def main():
             print(options.bank+" check: "+str(bank.check())+"\n")
             sys.exit(0)
 
-
         if options.status:
             if options.bank:
                 bank = Bank(options.bank, no_log=True)
@@ -352,8 +350,8 @@ def main():
                 print(tabulate(info['info'], headers='firstrow', tablefmt='psql'))
                 print(tabulate(info['prod'], headers='firstrow', tablefmt='psql'))
                 # do we have some pending release(s)
-                if 'pending' in info and len(info['pending']) > 1:
-                    print(tabulate(info['pending'], headers='firstrow', tablefmt='psql'))
+                if 'pend' in info and len(info['pend']) > 1:
+                    print(tabulate(info['pend'], headers='firstrow', tablefmt='psql'))
             else:
                 banks = Bank.list()
                 # Headers of output table

--- a/bin/biomaj-cli.py
+++ b/bin/biomaj-cli.py
@@ -5,7 +5,8 @@ standard_library.install_aliases()
 from builtins import str
 from tabulate import tabulate
 
-import os,sys
+import os
+import sys
 #from optparse import OptionParser
 import argparse
 import pkg_resources

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -141,7 +141,7 @@ class Bank(object):
         :type full: Boolean
         :return: Dict with keys
                       if full=True
-                           - info, prod, pending
+                           - info, prod, pend
                       else
                            - info
         '''
@@ -189,13 +189,11 @@ class Bank(object):
             return info
 
         else:
+            release = 'N/A'
             if 'current' in _bank and _bank['current']:
                 for prod in _bank['production']:
                     if _bank['current'] == prod['session']:
                         release = prod['remoterelease']
-            else:
-                release = 'N/A'
-            # return [ _bank['name'], ','.join(_bank['properties']['type']), str(release), _bank['properties']['visibility'] ]
             info['info'] = [_bank['name'], ','.join(_bank['properties']['type']),
                             str(release), _bank['properties']['visibility']]
             return info

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -178,10 +178,11 @@ class Bank(object):
                                   'yes' if 'freeze' in prod and prod['freeze'] else 'no'])
             # Bank pending info header
             if 'pending' in _bank and len(_bank['pending'].keys()) > 0:
-                pend_info.append(["Pending release(s)"])
+                pend_info.append(["Pending release", "Last run"])
                 for pending in _bank['pending'].keys():
-                    pend_info.append(pending)
-            # return [ bank_info, prod_info, pend_info ]
+                    run = datetime.fromtimestamp(_bank['pending'][pending]).strftime('%Y-%m-%d %H:%M:%S')
+                    pend_info.append([pending, run])
+
             info['info'] = bank_info
             info['prod'] = prod_info
             info['pend'] = pend_info


### PR DESCRIPTION
As previously updated for option ```--status``` I've updated and used ```tabulate``` python package to display the other infor given by options ```--search``` and ```--show```:

Now ```--show``` display info as such:
```
$ biomaj-cli.py --show --bank vipr_nt
+---------+------------+-------------+-----------+----------+-----------+
| Name    | Release    | Format(s)   | Type(s)   | Tag(s)   | File(s)   |
+=========+============+=============+===========+==========+===========+
| vipr_nt | 2015-03-03 | fasta       |           |          |           |
+---------+------------+-------------+-----------+----------+-----------+
| vipr_nt | 2015-04-27 | fasta       |           |          |           |
+---------+------------+-------------+-----------+----------+-----------+
| vipr_nt | 2015-06-16 | fasta       |           |          |           |
+---------+------------+-------------+-----------+----------+-----------+
```

```--search``` (example) as such:
```
$ biomaj-cli.py --search                            
Search by formats=[], types=[]
+-------------------------+----------------+-------------+-----------+-----------+
| Name                    | Release        | Format(s)   | Type(s)   | Current   |
+=========================+================+=============+===========+===========+
| alu                     | 2003-11-26__8  | fasta       |           |           |
+-------------------------+----------------+-------------+-----------+-----------+
|                         | 2003-11-26__7  | fasta       |           |           |
+-------------------------+----------------+-------------+-----------+-----------+
| borrelia                | 2014-01-13__1  | genbank     |           |           |
+-------------------------+----------------+-------------+-----------+-----------+
|                         | 2014-01-13     | genbank     |           |           |
+-------------------------+----------------+-------------+-----------+-----------+
| bsubtilis               | 2014-01-13__1  | genbank     |           |           |
+-------------------------+----------------+-------------+-----------+-----------+
...
```

```--search --query to``` as such:
```
Query matches for :to
+-----------+-------------+-----------+-------------------+
|   Release | Format(s)   | Type(s)   | Files             |
+===========+=============+===========+===================+
|         1 | format1     | nucl,prot | file1,file2,file3 |
+-----------+-------------+-----------+-------------------+
|         2 | format2     | nucl      | file4,file5,file6 |
+-----------+-------------+-----------+-------------------+
|         3 | format3     | nucl,prot | file1,file2,file3 |
+-----------+-------------+-----------+-------------------+
```

Tell me what do you think?

Emmanuel
