### PR TITLE
Don't throw if file list from local_file (cache.dir) is empty or None

### DIFF
--- a/biomaj/download/interface.py
+++ b/biomaj/download/interface.py
@@ -173,9 +173,13 @@ class DownloadInterface(object):
         :type root_dir: str
         :param check_exists: checks if file exists locally
         :type check_exists: bool
+        :return: List
         '''
 
         self.files_to_copy = []
+        # In such case, it forces the download again
+        if not available_files:
+            return self.files_to_copy
         available_files.sort(key=lambda x: x['name'])
         self.files_to_download.sort(key=lambda x: x['name'])
 

--- a/biomaj/download/interface.py
+++ b/biomaj/download/interface.py
@@ -179,7 +179,7 @@ class DownloadInterface(object):
         self.files_to_copy = []
         # In such case, it forces the download again
         if not available_files:
-            return self.files_to_copy
+            return
         available_files.sort(key=lambda x: x['name'])
         self.files_to_download.sort(key=lambda x: x['name'])
 

--- a/biomaj/download/interface.py
+++ b/biomaj/download/interface.py
@@ -173,7 +173,6 @@ class DownloadInterface(object):
         :type root_dir: str
         :param check_exists: checks if file exists locally
         :type check_exists: bool
-        :return: List
         '''
 
         self.files_to_copy = []


### PR DESCRIPTION
Hi,

I've been facing a small bug when `local_file.<session_id>` is not found or empty.
  "'NoneType' object has no attribute 'sort'". This fix force the download again nevertheless.
This small patch fixes the problem, but it forces the download again of the file(s). This happens for sure after a fresh migration. I'm working on a fix in `biomaj-migrate` to solve this issue.

Emmanuel