### PR TITLE
Added "Last run" date when displaying ko bank(s)

### DIFF
--- a/bin/biomaj-cli.py
+++ b/bin/biomaj-cli.py
@@ -396,7 +396,7 @@ def main():
 
         if options.statusko:
             banks = Bank.list()
-            banks_list = [["Name", "Type(s)", "Release", "Visibility"]]
+            banks_list = [["Name", "Type(s)", "Release", "Visibility", "Last run"]]
             for bank in sorted(banks, key=lambda k: k['name']):
                 try:
                     bank = Bank(bank['name'], no_log=True)

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -246,7 +246,8 @@ class Bank(object):
                     if _bank['current'] == prod['session']:
                         release = prod['remoterelease']
             info['info'] = [_bank['name'], ','.join(_bank['properties']['type']),
-                            str(release), _bank['properties']['visibility']]
+                            str(release), _bank['properties']['visibility'],
+                            datetime.fromtimestamp(_bank['last_update_session']).strftime('%Y-%m-%d %H:%M:%S')]
             return info
 
     def update_dependencies(self):


### PR DESCRIPTION
Hi,

I though it could be a good info to display ?
```
+-----------------+-----------+------------+--------------+---------------------+
| Name            | Type(s)   | Release    | Visibility   | Last run            |
|-----------------+-----------+------------+--------------+---------------------|
| embl_wgs_update | nucleic   | 2016-05-18 | public       | 2016-06-02 02:45:10 |
| gembase_genomes | protein   | 2015-11-30 | public       | 2016-05-10 14:03:23 |
| genbank_wgs     | nucleic   | 2015-07-31 | public       | 2016-05-03 11:38:07 |
| hg19            | genome    | 37         | public       | 2016-05-23 23:00:07 |
| mm10            | genome    | 38         | public       | 2016-05-23 23:00:07 |
| mm9             | genome    | 37         | public       | 2016-05-23 23:00:07 |
+-----------------+-----------+------------+--------------+---------------------+
```
Last column available from `bank.get_bank_release_info` (`full=False`)
Emmanuel