### PR TITLE
Do the schema migration as post install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ branches:
 #  - "sudo apt-get update -qq"
 #  - "sudo apt-get install -qq libldap2-dev libsasl2-dev"
 install:
+  - "pip install -r requirements.txt"
   - "pip install coverage"
   - "pip install python-coveralls"
   - "python setup.py -q install"

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -73,21 +73,6 @@ class Bank(object):
                            BiomajConfig.global_config.get('GENERAL', 'db.name'))
 
         self.banks = MongoConnector.banks
-
-
-        self.schema = MongoConnector.db_schema
-        self.schema_version = self.schema.find_one({'id': 1})
-        version = pkg_resources.get_distribution("biomaj").version
-        if self.schema_version is None:
-            self.schema_version = {'id': 1, 'version': '3.0.0'}
-            self.schema.insert({'id': 1, 'version': self.schema_version})
-        biomaj_version = self.schema_version['version'].split('.')
-        if self.schema_version != version:
-            self.migrate(biomaj_version)
-        else:
-            logging.debug("Schema: OK")
-
-
         self.bank = self.banks.find_one({'name': self.name})
 
         if self.bank is None:
@@ -102,35 +87,6 @@ class Bank(object):
 
         self.session = None
         self.use_last_session = False
-
-    def migrate(self, old_version):
-        """
-        Migrate database
-        """
-        if int(old_version[1]) == 0 and int(old_version[2]) <= 17:
-            logging.warn("Migrate from release: %s" %old_version)
-            # Update pending releases
-            banks = self.banks.find()
-            updated = 0
-            for bank in banks:
-                if 'pending' in bank:
-                    # Check we have an old pending type
-                    if type(bank['pending']) == dict:
-                        updated += 1
-                        pendings = []
-                        for release in sorted(bank['pending'], key=lambda r: bank['pending'][r]):
-                            pendings.append({'release': str(release), 'id': bank['pending'][str(release)]})
-                        if len(pendings) > 0:
-                            self.banks.update({'name': bank['name']},
-                                                        {'$set': {'pending': pendings}})
-                        else:
-                            # We remove old type for 'pending'
-                            self.banks.update({'name': bank['name']},
-                                                        {'$unset': {'pending': ""}})
-
-            logging.warn("Migration: %d bank(s) updated" % updated)
-
-        self.schema_version = self.schema.update_one({'id': 1},{'$set': {'version': pkg_resources.get_distribution("biomaj").version}})
 
     def check(self):
         """

--- a/biomaj/schema_version.py
+++ b/biomaj/schema_version.py
@@ -1,0 +1,64 @@
+import pkg_resources
+from biomaj.mongo_connector import MongoConnector
+from biomaj.config import BiomajConfig
+
+
+class SchemaVersion(object):
+
+    """
+    BioMAJ database schema version. This package can be used to make some schema modification if needed during
+    incremental software version.
+    """
+
+    @staticmethod
+    def migrate_pendings():
+        """
+        Migrate database
+
+        3.0.18: Check the actual BioMAJ version and if older than 3.0.17, do the 'pending' key migration
+        """
+        if BiomajConfig.global_config is None:
+            try:
+                BiomajConfig.load_config()
+            except Exception as err:
+                print("* SchemaVersion: Can't find config file")
+                return None
+        if MongoConnector.db is None:
+            MongoConnector(BiomajConfig.global_config.get('GENERAL', 'db.url'),
+                           BiomajConfig.global_config.get('GENERAL', 'db.name'))
+
+        schema = MongoConnector.db_schema
+        banks = MongoConnector.banks
+
+        schema_version = schema.find_one({'id': 1})
+        installed_version = pkg_resources.get_distribution("biomaj").version
+        if schema_version is None:
+            schema_version = {'id': 1, 'version': '3.0.0'}
+            schema.insert(schema_version)
+
+        moderate = int(schema_version['version'].split('.')[1])
+        minor = int(schema_version['version'].split('.')[2])
+
+        if moderate == 0 and minor <= 17:
+            print("Migrate from release: %s" % schema_version['version'])
+            # Update pending releases
+            bank_list = banks.find()
+            updated = 0
+            for bank in bank_list:
+                if 'pending' in bank:
+                    # Check we have an old pending type
+                    if type(bank['pending']) == dict:
+                        updated += 1
+                        pendings = []
+                        for release in sorted(bank['pending'], key=lambda r: bank['pending'][r]):
+                            pendings.append({'release': str(release), 'id': bank['pending'][str(release)]})
+                            if len(pendings) > 0:
+                                banks.update({'name': bank['name']},
+                                             {'$set': {'pending': pendings}})
+                    else:
+                        # We remove old type for 'pending'
+                        banks.update({'name': bank['name']},
+                                     {'$unset': {'pending': ""}})
+
+            print("Migration: %d bank(s) updated" % updated)
+        schema.update_one({'id': 1}, {'$set': {'version': installed_version}})

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ nose
 pymongo==3.2
 pycurl
 tabulate
+ldap3
+py-bcrypt
+drmaa
+future
+elasticsearch

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,15 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from distutils.command.install import install
 import os
+
+
+class post_install(install):
+    def run(self):
+        install.run(self)
+        from biomaj.schema_version import SchemaVersion
+        SchemaVersion.migrate_pendings()
 
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md')) as f:
@@ -42,20 +50,20 @@ config = {
         'Programming Language :: Python :: 3.4'
     ],
     'install_requires': ['nose',
-                            'pymongo==3.2',
-                            'pycurl',
-                            'ldap3',
-                            'mock',
-                            'py-bcrypt',
-                            'mock',
-                            'drmaa',
-                            'future',
-                            'tabulate',
-                            'elasticsearch'],
+                         'pymongo==3.2',
+                         'pycurl',
+                         'ldap3',
+                         'mock',
+                         'py-bcrypt',
+                         'drmaa',
+                         'future',
+                         'tabulate',
+                         'elasticsearch'],
     'packages': find_packages(),
     'include_package_data': True,
     'scripts': ['bin/biomaj-cli.py'],
-    'name': 'biomaj'
+    'name': 'biomaj',
+    'cmdclass': {'install': post_install},
 }
 
 setup(**config)


### PR DESCRIPTION
Hi,

I found better (tell me if I'm wrong) to do the schema migration during install step instead checking it each time we build a bank object.
It does some changes, especially to get travis-ci to work and to pass tests but it works.
Thus, we will be able to pass future modification to the database once we install a new version if required.

Emmanuel