### PR TITLE
Avoid duplicate in `pending`

### DIFF
--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -466,9 +466,11 @@ class Bank(object):
         if self.session.get('action') == 'update' and not self.session.get_status(Workflow.FLOW_OVER)\
                 and self.session.get('release'):
             release = self.session.get('release')
-            self.banks.update({'name': self.name},
-                              {'$push': {'pending': {'release': self.session.get('release'),
-                                                     'id': self.session._session['id']}}})
+            found = self.banks.find_one({'name': self.name, 'pending.release': release})
+            if found is None:
+                self.banks.update({'name': self.name},
+                                  {'$push': {'pending': {'release': self.session.get('release'),
+                                                         'id': self.session._session['id']}}})
 
         if self.session.get('action') == 'update' and self.session.get_status(Workflow.FLOW_OVER) and self.session.get(
                 'update'):


### PR DESCRIPTION
Hi,

When running multiple time an update, which may fail, BioMAJ stores the pending sessions, because it failed in duplicate for the same release:
```
{
  "pending": [
    {
      "release": "2016-06-03",
      "id": 1465945202.222075
    },
    {
      "release": "2016-06-03",
      "id": 1465945202.222075
    },
    {
      "release": "2016-06-03",
      "id": 1465945202.222075
    },
    {
      "release": "2016-06-03",
      "id": 1465945202.222075
    }
  ]
}

```
This should avoid this.

Thanks

Emmanuel