### PR TITLE
Fixes 'KeyError' with `--status` for new bank

### DIFF
--- a/bin/biomaj-cli.py
+++ b/bin/biomaj-cli.py
@@ -387,7 +387,7 @@ def main():
             else:
                 banks = Bank.list()
                 # Headers of output table
-                banks_list = [["Name", "Type(s)", "Release", "Visibility"]]
+                banks_list = [["Name", "Type(s)", "Release", "Visibility", "Last update"]]
                 for bank in sorted(banks, key=lambda k: k['name']):
                     bank = Bank(bank['name'], no_log=True)
                     banks_list.append(bank.get_bank_release_info()['info'])

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -149,12 +149,16 @@ class Bank(object):
 
         _bank = self.bank
         info = {}
+        release = 'N/A'
+        last_update = 'N/A'
+        if 'last_update_session' in _bank:
+            last_update = datetime.fromtimestamp(_bank['last_update_session']).strftime("%Y-%m-%d %H:%M:%S")
 
         if full:
             bank_info = []
             prod_info = []
             pend_info = []
-            release = None
+
             if 'current' in _bank and _bank['current']:
                 for prod in _bank['production']:
                     if _bank['current'] == prod['session']:
@@ -163,7 +167,7 @@ class Bank(object):
             bank_info.append(["Name", "Type(s)", "Last update status", "Published release"])
             bank_info.append([_bank['name'],
                               str(','.join(_bank['properties']['type'])),
-                              str(datetime.fromtimestamp(_bank['last_update_session']).strftime("%Y-%m-%d %H:%M:%S")),
+                              str(last_update),
                               str(release)])
             # Bank production info header
             prod_info.append(["Session", "Remote release", "Release", "Directory", "Freeze"])
@@ -196,14 +200,12 @@ class Bank(object):
             return info
 
         else:
-            release = 'N/A'
             if 'current' in _bank and _bank['current']:
                 for prod in _bank['production']:
                     if _bank['current'] == prod['session']:
                         release = prod['remoterelease']
             info['info'] = [_bank['name'], ','.join(_bank['properties']['type']),
-                            str(release), _bank['properties']['visibility'],
-                            datetime.fromtimestamp(_bank['last_update_session']).strftime('%Y-%m-%d %H:%M:%S')]
+                            str(release), _bank['properties']['visibility'], last_update]
             return info
 
     def update_dependencies(self):

--- a/biomaj/workflow.py
+++ b/biomaj/workflow.py
@@ -468,8 +468,6 @@ class UpdateWorkflow(Workflow):
             else:
                 release_downloader = self.get_handler(protocol, server, remote_dir)
 
-
-            #release_downloader = self.get_handler(protocol, server, remote_dir)
             if cf.get('server.credentials') is not None:
                 release_downloader.set_credentials(cf.get('server.credentials'))
 
@@ -537,11 +535,6 @@ class UpdateWorkflow(Workflow):
                 self.session.set('release', release+'__'+str(index))
                 release = release+'__'+str(index)
 
-        #if self.options.get_option(Options.FROMSCRATCH) and os.path.exists(self.session.get_full_release_directory()):
-        #  index = 1
-        #  while os.path.exists(self.session.get_full_release_directory()+'_'+str(index)):
-        #    index += 1
-        #  self.session.set('release', release+'_'+str(index))
         self.download_go_ahead = False
         if self.options.get_option(Options.FROM_TASK) == 'download':
             # We want to download again in same release, that's fine, we do not care it is the same release


### PR DESCRIPTION
Hi,

When a new bank is created, or not updated yet, asking for `--status` throws a `KeyError 'last_update_session'`. This pull request fixes this error. It also fixes a shift in the output between table banner and data.

Emmanuel