### PR TITLE
Update pending only once

### DIFF
--- a/biomaj/schema_version.py
+++ b/biomaj/schema_version.py
@@ -52,9 +52,9 @@ class SchemaVersion(object):
                         pendings = []
                         for release in sorted(bank['pending'], key=lambda r: bank['pending'][r]):
                             pendings.append({'release': str(release), 'id': bank['pending'][str(release)]})
-                            if len(pendings) > 0:
-                                banks.update({'name': bank['name']},
-                                             {'$set': {'pending': pendings}})
+                        if len(pendings) > 0:
+                            banks.update({'name': bank['name']},
+                                         {'$set': {'pending': pendings}})
                     else:
                         # We remove old type for 'pending'
                         banks.update({'name': bank['name']},


### PR DESCRIPTION
Hi,
Quick fix about `schema_version.py` as I've noticed that we update `pending` key each time we find a old style release.
This update the `pending` key only if we've found some release to update from old to new style.
Let me know