### PR TITLE
Check process exists with `--from-task` and `--process`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@
   Feature #65 add a release info file at the root of the bank which can be used by other services to know the latest release available
   Feature #25 experimental support of rsync protocol
   Add rate limiting for download with micro services
+  Limit email size to 2Mb, log file may be truncated
 3.0.20:
   Fix #55: Added support for https and directhttps
   Add possibility to define files to download from a local file with remote.list parameter

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.1.0:
+  ## Needs database upgrade
   If using biomaj-watcher, must use version >= 3.1.0
   Feature #67,#66,#61 switch to micro service architecture. Still works in local monolithic install
   Fix some configuration parameter loading when not defined in config

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ downloaded again only if a change is detected.
 
 More documentation is available in wiki page.
 
+BioMAJ is python 2 and 3 compatible.
+
 Getting started
 ===============
 
@@ -38,6 +40,10 @@ Migration for 3.0 to 3.1:
 
 Biomaj 3.1 provides an optional micro service architecture, allowing to separate and distributute/scale biomaj components on one or many hosts. This implementation is optional but recommended for server installations. Monolithic installation can be kept for local computer installation.
 To upgrade an existing 3.0 installation, as biomaj code has been split into multiple components, it is necessary to install/update biomaj python package but also biomaj-cli and biomaj-daemon packages. Then database must be upgraded manually (see Upgrading in documentation).
+
+To execute database migration:
+
+    python biomaj_migrate_database.py
 
 Application Features
 ====================

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -1080,11 +1080,10 @@ class Bank(object):
                     if task['name'] in [Workflow.FLOW_POSTPROCESS, Workflow.FLOW_PREPROCESS,
                                         Workflow.FLOW_REMOVEPROCESS]:
                         proc = self.options.get_option('process')
-                        self.session.reset_proc(task['name'], proc)
-                        if not self.session.reset_done:
-                            logging.error("Process %s not found in %s" % (str(proc), task['name']))
+                        reset = self.session.reset_proc(task['name'], proc)
+                        if not reset:
+                            logging.info("Process %s not found in %s" % (str(proc), task['name']))
                             return False
-
 
         self.session.set('action', 'update')
         res = self.start_update()

--- a/biomaj/bank.py
+++ b/biomaj/bank.py
@@ -1081,6 +1081,10 @@ class Bank(object):
                                         Workflow.FLOW_REMOVEPROCESS]:
                         proc = self.options.get_option('process')
                         self.session.reset_proc(task['name'], proc)
+                        if not self.session.reset_done:
+                            logging.error("Process %s not found in %s" % (str(proc), task['name']))
+                            return False
+
 
         self.session.set('action', 'update')
         res = self.start_update()

--- a/biomaj/notify.py
+++ b/biomaj/notify.py
@@ -36,7 +36,7 @@ class Notify(object):
                 fp = open(log_file, 'rb')
             else:
                 fp = open(log_file, 'r')
-            msg = MIMEText(fp.read())
+            msg = MIMEText(fp.read(2000000))
             fp.close()
 
         msg['From'] = email.utils.formataddr(('Author', mfrom))

--- a/biomaj/session.py
+++ b/biomaj/session.py
@@ -43,6 +43,7 @@ class Session(object):
         self.name = name
         self.config = config
         self.flow = copy.deepcopy(flow)
+        self.reset_done = False
 
         formats = {}
         if self.config.get('db.formats') is not None:
@@ -156,6 +157,7 @@ class Session(object):
                 set_to_false = True
             if set_to_false:
                 processes[process] = False
+        self.reset_done = set_to_false
 
     def load(self, session):
         """

--- a/biomaj/session.py
+++ b/biomaj/session.py
@@ -5,7 +5,6 @@ import os
 import time
 import copy
 import sys
-import logging
 
 from biomaj.workflow import Workflow
 
@@ -124,7 +123,7 @@ class Session(object):
         :type proc: str
         """
         # If --process option not given on command line, we won't find it in following loop(s)
-        if proc == None:
+        if proc is None:
             self._reset_done = True
         if type_proc == Workflow.FLOW_POSTPROCESS:
             if proc in self._session['process']['postprocess']:

--- a/scripts/biomaj_migrate_database.py
+++ b/scripts/biomaj_migrate_database.py
@@ -1,0 +1,7 @@
+from biomaj.schema_version import SchemaVersion
+import logging
+
+logging.warn('Migrate BioMAJ database...')
+logging.warn('Needs global.properties in local directory or env variable BIOMAJ_CONF')
+SchemaVersion.migrate_pendings()
+logging.warn('Migration done')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ config = {
     'test_suite': 'nose.collector',
     'packages': find_packages(),
     'include_package_data': True,
-    'scripts': [],
+    'scripts': ['scripts/biomaj_migrate_database.py'],
     'name': 'biomaj',
     'cmdclass': {'install': post_install},
 }

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -661,6 +661,21 @@ class TestBiomajFunctional(unittest.TestCase):
     #self.assertFalse(os.path.exists(proc1file))
     self.assertTrue(os.path.exists(proc2file))
 
+  @attr('process')
+  def test_postprocess_wrong_process_name(self):
+    """If a wrong process name is given, update returns False and prints an error message"""
+    b = Bank('local')
+    b.options.stop_after = 'download'
+    b.update()
+    self.assertFalse(b.session.get_status('postprocess'))
+    b2 = Bank('local')
+    b2.options.from_task = 'postprocess'
+    b2.options.release = b.session.get('release')
+    b2.options.process = 'fake'
+    self.assertFalse(b2.update())
+    self.assertFalse(b2.session.get_status('postprocess'))
+    self.assertEqual(b.session.get_full_release_directory(), b2.session.get_full_release_directory())
+
   def test_computed(self):
     b = Bank('computed')
     res = b.update(True)


### PR DESCRIPTION
Hi,

It looks like when we restart a workflow using `--from-task`, value for `--from-task` is well checked and exists in database status, however, value for `--process` is not.
I've tried to mimic the same behavior by this pull request.
Please check it and let me know if it makes sense or not.

Emmanuel