### PR TITLE
Allow to use hardlinks when reusing files from previous releases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.1.10:
+  Allow to use hardlinks when reusing files from previous releases
 3.1.9:
   Fix remote.files recursion
 3.1.8:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-biomaj_core
+biomaj_core>=3.0.18
 biomaj_user
-biomaj_download>=3.0.20
+biomaj_download>=3.0.25
 biomaj_process>=3.0.12
 biomaj_cli
 mock

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ config = {
     'url': 'http://biomaj.genouest.org',
     'download_url': 'http://biomaj.genouest.org',
     'author_email': 'olivier.sallou@irisa.fr',
-    'version': '3.1.9',
+    'version': '3.1.10',
      'classifiers': [
         # How mature is this project? Common values are
         #   3 - Alpha


### PR DESCRIPTION
This PR enables the use of hardlinks when updating banks. More precisely, we can create hardlinks when reusing files from a previous release (if the underlying filesystem allows it). By default, this is not enbaled so backward compatibility is assured.