### PR TITLE
Allow ftps and directftps protocols in core

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Application Features
 ====================
 
 * Synchronisation:
- * Multiple remote protocols (ftp, sftp, http, local copy, etc.)
+ * Multiple remote protocols (ftp, ftps, http, local copy, etc.)
  * Data transfers integrity check
  * Release versioning using a incremental approach
  * Multi threading
@@ -194,8 +194,6 @@ A-GPL v3+
 
 Remarks
 =======
-
-Biomaj uses libcurl, for sftp libcurl must be compiled with sftp support
 
 To delete elasticsearch index:
 

--- a/biomaj/workflow.py
+++ b/biomaj/workflow.py
@@ -607,7 +607,7 @@ class UpdateWorkflow(Workflow):
 
             save_as = None
             method = 'GET'
-            if protocol == 'directhttp' or protocol == 'directhttps' or protocol == 'directftp':
+            if protocol in ['directftp', 'directftps', 'directhttp', 'directhttps']:
                 keys = cf.get('url.params')
                 if keys is not None:
                     params = {}
@@ -650,7 +650,7 @@ class UpdateWorkflow(Workflow):
                 offline_dir=self.session.get_offline_directory()
             )
 
-            if protocol == 'directhttp' or protocol == 'directhttps' or protocol == 'directftp':
+            if protocol in ['directftp', 'directftps', 'directhttp', 'directhttps']:
                 release_downloader.set_files_to_download(remotes)
             # """"""""""""""""""""""""
 
@@ -1098,7 +1098,7 @@ class UpdateWorkflow(Workflow):
 
             remote_dir = cf.get('remote.dir')
 
-            if protocol == 'directhttp' or protocol == 'directhttps' or protocol == 'directftp':
+            if protocol in ['directftp', 'directftps', 'directhttp', 'directhttps']:
                 keys = cf.get('url.params')
                 if keys is not None:
                     params = {}
@@ -1139,7 +1139,7 @@ class UpdateWorkflow(Workflow):
                 offline_dir=self.session.get_offline_directory()
             )
 
-            if protocol == 'directhttp' or protocol == 'directhttps' or protocol == 'directftp':
+            if protocol in ['directftp', 'directftps', 'directhttp', 'directhttps']:
                 downloader.set_files_to_download(remotes)
 
             remote_list = cf.get('remote.list', default=None)


### PR DESCRIPTION
This PR is a follow-up to genouest/biomaj-download#12 and genouest/biomaj-core#3 to allow ftps and directftps in core.