### PR TITLE
Correctly use save_as for release file (if needed).

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 3.1.12 [unreleased]:
   In case of multiple matches for release regexp, try to determine most recent one
+  #115 Correctly use save_as for release file name
 3.1.11:
   Increase one log level
   #110 Allow ftps and directftps protocols (needs biomaj-download 3.0.26 and biomaj-core 3.0.19)

--- a/biomaj/workflow.py
+++ b/biomaj/workflow.py
@@ -774,10 +774,13 @@ class UpdateWorkflow(Workflow):
                 tmp_dir = tempfile.mkdtemp('biomaj')
                 rel_files = release_downloader.download(tmp_dir)
                 rel_file = None
+                rel_file_name = rel_files[0]['name']
+                if 'save_as' in rel_files[0] and rel_files[0]['save_as']:
+                    rel_file_name = rel_files[0]['save_as']
                 if (sys.version_info > (3, 0)):
-                    rel_file = open(tmp_dir + '/' + rel_files[0]['name'], encoding='utf-8', errors='ignore')
+                    rel_file = open(tmp_dir + '/' + rel_file_name, encoding='utf-8', errors='ignore')
                 else:
-                    rel_file = open(tmp_dir + '/' + rel_files[0]['name'])
+                    rel_file = open(tmp_dir + '/' + rel_file_name)
                 rel_content = rel_file.read()
                 rel_file.close()
                 shutil.rmtree(tmp_dir)


### PR DESCRIPTION
In case the release number is read from a file and this file is saved under a different name (with the appropriate option), we must use the `save_as` property to forge the release filename instead of `name`.

It doesn't create problems now because direct downloaders set `name` to `save_as` after downloading but we plan to change that in which case it will be needed.