### PR TITLE
remove usage of old external mock library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 import sys
 import os
 
-from mock import Mock as MagicMock
+from unittest.mock import Mock as MagicMock
 
 class Mock(MagicMock):
     @classmethod
@@ -222,8 +222,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'BioMAJ.tex', u'BioMAJ Documentation',
-   u'Olivier Sallou', 'manual'),
+  ('index', 'BioMAJ.tex', 'BioMAJ Documentation',
+   'Olivier Sallou', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -252,8 +252,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'biomaj', u'BioMAJ Documentation',
-     [u'Olivier Sallou'], 1)
+    ('index', 'biomaj', 'BioMAJ Documentation',
+     ['Olivier Sallou'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -266,8 +266,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'BioMAJ', u'BioMAJ Documentation',
-   u'Olivier Sallou', 'BioMAJ', 'Biological databanks update.',
+  ('index', 'BioMAJ', 'BioMAJ Documentation',
+   'Olivier Sallou', 'BioMAJ', 'Biological databanks update.',
    'Miscellaneous'),
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-mock
 nose
 pymongo==3.2
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ biomaj_user
 biomaj_download>=3.2.1
 biomaj_process>=3.0.12
 biomaj_cli
-mock
 pytest
 pymongo==3.12.3
 pycurl

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ config = {
                          'Yapsy==1.12.2',
                          'packaging'
                          ],
-    'tests_require': ['pytest', 'mock'],
+    'tests_require': ['pytest'],
     'packages': find_packages(),
     'include_package_data': True,
     'scripts': ['scripts/biomaj_migrate_database.py'],

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -6,12 +6,10 @@ import logging
 import copy
 import stat
 import time
-import pytest
-
-from mock import patch
-
 from optparse import OptionParser
+from unittest.mock import patch
 
+import pytest
 
 from biomaj.bank import Bank
 from biomaj.session import Session


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.