### PR TITLE
Fix issue when all files were already downloaded

### DIFF
--- a/biomaj/workflow.py
+++ b/biomaj/workflow.py
@@ -1435,7 +1435,7 @@ class UpdateWorkflow(Workflow):
                 everything_present = False
                 break
         if everything_present:
-            self.downloaded_files = []
+            self.downloaded_files = copied_files
             logging.info("Workflow:wf_download:all_files_in_offline:skip download")
             return True
 


### PR DESCRIPTION
Should fix #141 ... maybe

The issue was that if all files were already downloaded, self.downloaded_files was set to [].
But the following steps use it as a list of files to manage, so if it's empty, nothing else is done (despite the files not having been processed yet)